### PR TITLE
[REFACTORING] Déplacement du call API du composant vers la page Details

### DIFF
--- a/src/components/CardDetails/DetailsComponent.vue
+++ b/src/components/CardDetails/DetailsComponent.vue
@@ -1,33 +1,16 @@
 <script setup>
-import { ref } from 'vue'
-import { useRoute } from 'vue-router'
-import { getSpecificAnime } from '@/services/api'
-
-const route = useRoute()
-const id = route.params.id
-const animeDetails = ref({})
-
-const fetchSpecificAnime = async () => {
-  try {
-    const specificAnime = await getSpecificAnime(id)
-    animeDetails.value = specificAnime
-  } catch (error) {
-    console.error(error.message)
-  }
-}
-await fetchSpecificAnime()
+const props = defineProps(['title', 'image', 'synopsis'])
 </script>
 
 <template>
   <div class="h-screen">
     <div class="w-full flex space-x-4 p-4">
-      <img :src="animeDetails.image" alt="{{animeDetails.image}}" class="h-full aspect-auto" />
+      <img :src="props.image" alt="{{props.image}}" class="h-full aspect-auto" />
       <div class="flex-col">
-        <h1 class="font-bold text-xl">{{ animeDetails.title }}</h1>
-        <p class="my-4 text-justify" v-if="animeDetails.synopsis">
-          {{ animeDetails.synopsis }}
+        <h1 class="font-bold text-xl">{{ props.title }}</h1>
+        <p class="my-4 text-justify">
+          {{ props.synopsis }}
         </p>
-        <p class="my-4 text-justify" v-else>Pas de synopsis disponible</p>
       </div>
     </div>
   </div>

--- a/src/views/DetailsPage/DetailPage.vue
+++ b/src/views/DetailsPage/DetailPage.vue
@@ -1,13 +1,48 @@
 <script setup>
+import { ref, computed } from 'vue'
 import DetailsComponent from '@/components/CardDetails/DetailsComponent.vue'
 import defaultLayout from '@/layouts/defaultLayout.vue'
+import { useRoute } from 'vue-router'
+import { getSpecificAnime } from '@/services/api'
+
+const route = useRoute()
+const id = route.params.id
+const anime = ref({})
+const isLoading = ref(true)
+
+function isEmpty(obj) {
+  return Object.keys(obj).length === 0
+}
+
+const fetchSpecificAnime = async () => {
+  try {
+    const specificAnime = await getSpecificAnime(id)
+    anime.value = specificAnime
+  } catch (error) {
+    console.error(error.message)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+fetchSpecificAnime()
+
+const animeSynopsis = computed(() => {
+  return anime.value.synopsis || 'Pas de synopsis disponible'
+})
 </script>
 
 <template>
   <defaultLayout>
-    <Suspense>
-      <DetailsComponent />
-      <template v-slot:fallback>En cours de chargement ...</template>
-    </Suspense>
+    <p v-if="isLoading">En cours de chargement...</p>
+    <div v-else>
+      <DetailsComponent
+        v-if="!isEmpty(anime)"
+        :title="anime.title"
+        :image="anime.image"
+        :synopsis="animeSynopsis"
+      />
+      <p v-else>Not found</p>
+    </div>
   </defaultLayout>
 </template>


### PR DESCRIPTION
## ❌ Problème

Call API à placer dans la page et pas dans le composant (pas de métier dans les composants qui gèrent l'affichage)

## 🎁 Proposition

- Retrait du call API dans le composant **DetailsComponent.vue**
- Création du call API dans la page **DetailPage.vue**
- Passage des props de la page vers le composant
- Gestion d'erreurs et de chargement

## 🌈 Remarques

RAS

## 💯 Pour tester
```
npm run dev
```
