### PR TITLE
[FEATURE] gérer l'image de detail page dans le cas où celle ci n'est pas chargée

### DIFF
--- a/src/components/CardDetails/DetailsComponent.vue
+++ b/src/components/CardDetails/DetailsComponent.vue
@@ -1,11 +1,20 @@
 <script setup>
+import noImageAvailable from '@/assets/SVG/no_image_available.svg'
 const props = defineProps(['title', 'image', 'synopsis'])
+const handleImageError = (event) => {
+  event.target.src = noImageAvailable
+}
 </script>
 
 <template>
   <div class="h-screen">
     <div class="w-full flex space-x-4 p-4">
-      <img :src="props.image" alt="{{props.image}}" class="h-full aspect-auto" />
+      <img
+        :src="props.image"
+        alt="{{props.image}}"
+        class="h-full aspect-auto"
+        @error="handleImageError"
+      />
       <div class="flex-col">
         <h1 class="font-bold text-xl">{{ props.title }}</h1>
         <p class="my-4 text-justify">


### PR DESCRIPTION
## ❌ Problème
- gérer l'image dans le cas où celle-ci n'est pas chargée.
## 🎁 Proposition
- intégration d'une fonction pour gérer la dite erreur
## 🌈 Remarques
-none
## 💯 Pour tester
-none
