### PR TITLE
[REFACTORING] Refactoring des tests suite à la suppression des boutons dans la searchBar

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:e2e": "playwright test",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
     "format": "prettier --write src/",
-    "test": "vitest"
+    "test:watch": "vitest",
+    "test": "vitest run"
   },
   "dependencies": {
     "vue": "^3.2.47",

--- a/src/components/Footer/Footer.test.js
+++ b/src/components/Footer/Footer.test.js
@@ -1,10 +1,14 @@
 import { render } from '@testing-library/vue'
-import { expect, test } from 'vitest'
+import { test } from 'vitest'
 import Footer from './Footer.vue'
 import '@testing-library/jest-dom'
+import router from '@/router'
 
 test('footer has the text "Twitter"', async () => {
-  const { getByText } = render(Footer)
-  const elem = getByText('Twitter')
-  expect(elem).toBeInTheDocument()
+  const { getByRole } = render(Footer, {
+    global: {
+      plugins: [router]
+    }
+  })
+  getByRole('link', { name: 'Twitter' })
 })

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -1,14 +1,14 @@
 import { render } from '@testing-library/vue'
-import { expect, test, vi } from 'vitest'
+import { test } from 'vitest'
 import Header from './Header.vue'
 import '@testing-library/jest-dom'
-
-vi.mock('vue-router', () => ({
-  RouterLink: vi.fn()
-}))
+import router from '@/router'
 
 test('header has the text "Valeurs"', async () => {
-  const { getByText } = render(Header)
-  const elem = getByText('Valeurs')
-  expect(elem).toBeInTheDocument()
+  const { getByRole } = render(Header, {
+    global: {
+      plugins: [router]
+    }
+  })
+  getByRole('link', { name: 'Valeurs' })
 })

--- a/src/components/SearchBar/SearchBar.test.js
+++ b/src/components/SearchBar/SearchBar.test.js
@@ -1,41 +1,9 @@
-import { fireEvent, render } from '@testing-library/vue'
-import { expect, test, describe } from 'vitest'
+import { render } from '@testing-library/vue'
+import { test } from 'vitest'
 import SearchBar from './SearchBar.vue'
 import '@testing-library/jest-dom'
 
-test('button Search is present', async () => {
-  const { getByText } = render(SearchBar)
-  const elem = getByText('Search')
-  expect(elem).toBeInTheDocument()
-})
-
-describe('When I write something in the input', () => {
-  test('The Clear button should be here', async () => {
-    const { getByText, getByPlaceholderText } = render(SearchBar)
-    const input = getByPlaceholderText('Search')
-    await fireEvent.update(input, 'test')
-    const elem = getByText('Clear')
-    expect(elem).toBeInTheDocument()
-  })
-})
-
-describe('WHen the input is empty', () => {
-  test('The Clear button should not be here', async () => {
-    const { queryByText, getByPlaceholderText } = render(SearchBar)
-    const input = getByPlaceholderText('Search')
-    await fireEvent.update(input, '')
-    const elem = queryByText('Clear')
-    expect(elem).not.toBeInTheDocument()
-  })
-})
-
-describe('When I click on the Clear button', () => {
-  test('The input should be empty', async () => {
-    const { getByText, getByPlaceholderText } = render(SearchBar)
-    const input = getByPlaceholderText('Search')
-    await fireEvent.update(input, 'test')
-    const clearButton = getByText('Clear')
-    await fireEvent.click(clearButton)
-    expect(input.value).toBe('')
-  })
+test('The input should be visible', async () => {
+  const { getByPlaceholderText } = render(SearchBar)
+  getByPlaceholderText('Search')
 })


### PR DESCRIPTION
## ❌ Problème

Tests échoués suite à la suppression des boutons **Search** & **Clear** dans la searchBar 
Tests échoués dans le Header & Footer suite au remplacement des balises `<a>` par des balises `<RouterLink>`

## 🎁 Proposition

Refactoring des fichiers **Header.test.js**, **Footer.test.js** et **SearchBar.test.js**
Intégration du mode **normal** et **:watch** pour les lancements des tests dans le **package.json**

## 🌈 Remarques

Les tests de la page Home sont toujours échoués, un refactoring de ceux-ci est nécessaire.
Le test e2e est à refactorer également.

## 💯 Pour tester

```
npm run test
```