### PR TITLE
[BUGFIX] Correction du fichier de test E2E

### DIFF
--- a/e2e/vue.spec.js
+++ b/e2e/vue.spec.js
@@ -2,23 +2,21 @@ import { test, expect } from '@playwright/test'
 
 test.describe('navigation', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('http://localhost:5174/')
+    await page.goto(process.env.VITE_APP_WEBSITE_LINK)
   })
   test('main navigation', async ({ page }) => {
     //URL ASSERTION
-    await expect(page).toHaveURL('http://localhost:5174/')
+    await expect(page).toHaveURL(process.env.VITE_APP_WEBSITE_LINK)
     //EXEPCT RENDER ELEMENTS
-    await expect(page.getByAltText('poster')).toHaveCount(30)
+    await expect(page.getByRole('article')).toHaveCount(30)
     //FIND INPU AND FILL WITH FULLMETAL
     await page.getByPlaceholder('Search').fill('Fullmetal')
-    //CLICK ON SEARCH BUTTON
-    await page.locator('button', { hasText: 'Search' }).click()
     //EXPECT RENDER ONLY ONE ELEMENT
-    await expect(page.getByAltText('poster')).toHaveCount(1)
+    await expect(page.getByRole('article')).toHaveCount(1)
     //ClICK ON IMAGE
-    await page.getByAltText('poster').click()
+    await page.getByRole('article').click()
     //URL ASSERTION
-    await expect(page).toHaveURL('http://localhost:5174/details/5114')
+    await expect(page).toHaveURL(process.env.VITE_APP_WEBSITE_LINK + 'details/5114')
     //RENDER TITLE
     await expect(page.getByText('Fullmetal Alchemist: Brotherhood', { exact: true })).toBeVisible()
     //RENDER SYSNOPSIS

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "poc2_vue",
       "version": "0.0.0",
       "dependencies": {
+        "dotenv": "^16.0.3",
         "vue": "^3.2.47",
         "vue-router": "^4.1.6"
       },
@@ -1557,6 +1558,14 @@
       "dependencies": {
         "webidl-conversions": "^7.0.0"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "dotenv": "^16.0.3",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -5,7 +5,7 @@ const { devices } = require('@playwright/test')
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// require('dotenv').config();
+require('dotenv').config()
 
 /**
  * @see https://playwright.dev/docs/test-configuration


### PR DESCRIPTION
## ❌ Problème

Suite à la suppression des boutons **Search** & **Clear** de notre searchBar, le test E2E avec Playwright ne fonctionnait plus.

## 🎁 Proposition

- Retrait des interactions avec les boutons, qui n'existent plus.
- Remplacement des `.getByAltText('poster')` par `.getByRole('article')` car les `alt` des images correspondent maintenant aux titres des animes.
- Remplacement des liens localhost par des variables d'environnement.

## 🌈 Remarques

Dans le fichier `.env`, implémenter la ligne suivante : 
```
VITE_APP_WEBSITE_LINK=http://localhost:5173/poc2_vue/
```
## 💯 Pour tester
```
npm run test:e2e
```
Éventuellement, pour avoir un rapport du test E2E, vous pouvez, une fois le test terminé, taper la commande suivante : 
```
npx playwright show-report
```